### PR TITLE
Implement Zap Imóveis rental price scraper and reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+data/
+*.sqlite
+*.db
+*.png

--- a/README.md
+++ b/README.md
@@ -1,3 +1,84 @@
 # Realstate Project
 
-This project is about managing real estate properties.
+Ferramenta para coletar diariamente informações de aluguel por m² em bairros de São Paulo utilizando o [Zap Imóveis](https://www.zapimoveis.com.br/).
+
+## Funcionalidades
+
+* Coleta automática dos preços de apartamentos para aluguel nos bairros **Pinheiros**, **Vila Madalena**, **Moema** e **Saúde**.
+* Diferencia apartamentos mobiliados e não mobiliados e calcula o preço por metro quadrado de cada anúncio.
+* Armazena o histórico de preços em um banco de dados SQLite para facilitar análises futuras.
+* Gera gráficos com a variação de preço de um mesmo imóvel e com o preço médio por m² de cada bairro.
+
+## Pré-requisitos
+
+* Python 3.11 ou superior.
+* Dependências opcionais:
+  * `matplotlib` para geração de gráficos (`pip install matplotlib`).
+
+## Estrutura do projeto
+
+```
+realstate/
+├── config.py            # Configurações e constantes principais
+├── scraper.py           # Cliente HTTP e normalização dos anúncios
+├── storage.py           # Persistência em SQLite
+├── reporting.py         # Funções para criação de gráficos
+└── main.py              # Interface de linha de comando
+tests/                   # Testes unitários (executáveis com `python -m unittest`)
+fixtures/                # Dados de exemplo usados nos testes
+data/                    # Pasta sugerida para o banco de dados SQLite e gráficos
+```
+
+## Executando a coleta
+
+Para executar uma coleta única e armazenar os resultados em `data/zap_rentals.sqlite`:
+
+```bash
+python -m realstate.main collect
+```
+
+Por padrão são coletadas informações dos bairros Pinheiros, Vila Madalena, Moema e Saúde. Para limitar a coleta a bairros específicos utilize a opção `--neighborhood` múltiplas vezes:
+
+```bash
+python -m realstate.main collect --neighborhood "Pinheiros" --neighborhood "Moema"
+```
+
+### Execução diária automática
+
+Utilize a flag `--daily` para manter a coleta ativa e repetir o processo a cada 24 horas (ou outro intervalo definido por `--interval-hours`):
+
+```bash
+python -m realstate.main collect --daily --interval-hours 24
+```
+
+Este comando pode ser agendado via `cron` (Linux/macOS) ou Agendador de Tarefas (Windows) para iniciar automaticamente junto com o sistema operacional.
+
+## Gerando gráficos
+
+Após coletar dados, é possível gerar gráficos diretamente pela linha de comando:
+
+* **Histórico de preço de um imóvel específico**:
+
+  ```bash
+  python -m realstate.main report listing ZAP_ID --output graficos/apartamento.png
+  ```
+
+  Substitua `ZAP_ID` pelo código do imóvel (ex.: `123456`). Utilize `--show` para exibir o gráfico em vez de salvá-lo em arquivo.
+
+* **Preço médio por m² de um bairro**:
+
+  ```bash
+  python -m realstate.main report neighborhood "Pinheiros" --output graficos/pinheiros.png
+  ```
+
+Os gráficos distinguem automaticamente imóveis mobiliados e não mobiliados.
+
+## Testes
+
+Para validar as funcionalidades principais execute:
+
+```bash
+python -m unittest discover -s tests -p 'test_*.py'
+```
+
+Os testes utilizam dados artificiais que simulam a resposta da API do Zap Imóveis para garantir o funcionamento das rotinas de coleta e armazenamento.

--- a/fixtures/sample_api_response.json
+++ b/fixtures/sample_api_response.json
@@ -1,0 +1,62 @@
+{
+  "listings": [
+    {
+      "listing": {
+        "id": "12345",
+        "title": "Apartamento mobiliado em Pinheiros",
+        "usableAreas": [80],
+        "bedrooms": 2,
+        "bathrooms": 2,
+        "parkingSpaces": 1,
+        "furnished": true,
+        "address": {
+          "street": "Rua dos Pinheiros",
+          "neighborhood": "Pinheiros",
+          "city": "São Paulo",
+          "state": "SP"
+        },
+        "pricingInfos": [
+          {
+            "businessType": "RENTAL",
+            "rentalTotalPrice": "4800",
+            "price": "4500",
+            "monthlyCondoFee": "600"
+          }
+        ],
+        "url": "https://www.zapimoveis.com.br/imovel/12345"
+      }
+    },
+    {
+      "listing": {
+        "listingId": "67890",
+        "advertiseTitle": "Apartamento amplo em Moema",
+        "usableAreas": 100,
+        "rooms": 3,
+        "bathrooms": 3,
+        "parkingSpaces": 2,
+        "amenities": ["Piscina", "Academia"],
+        "features": ["Varanda"],
+        "address": {
+          "street": "Avenida Ibirapuera",
+          "neighborhood": "Moema",
+          "city": "São Paulo",
+          "state": "SP"
+        },
+        "pricingInfos": [
+          {
+            "businessType": "SALE",
+            "price": "1000000"
+          },
+          {
+            "businessType": "RENTAL",
+            "price": "6000",
+            "monthlyCondoFee": "800"
+          }
+        ],
+        "link": {
+          "href": "https://www.zapimoveis.com.br/imovel/67890"
+        }
+      }
+    }
+  ]
+}

--- a/realstate/__init__.py
+++ b/realstate/__init__.py
@@ -1,0 +1,8 @@
+"""Ferramentas para coleta e análise de preços de aluguel do Zap Imóveis."""
+
+__all__ = [
+    "config",
+    "scraper",
+    "storage",
+    "reporting",
+]

--- a/realstate/config.py
+++ b/realstate/config.py
@@ -1,0 +1,41 @@
+"""Configuration for the real estate scraping project."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+
+@dataclass(frozen=True)
+class Neighborhood:
+    """Represents a neighborhood in São Paulo that should be scraped."""
+
+    name: str
+    query: str
+
+
+DEFAULT_NEIGHBORHOODS: List[Neighborhood] = [
+    Neighborhood(name="Pinheiros", query="Pinheiros"),
+    Neighborhood(name="Vila Madalena", query="Vila Madalena"),
+    Neighborhood(name="Moema", query="Moema"),
+    Neighborhood(name="Saúde", query="Saúde"),
+]
+
+# Base directory where generated artifacts (database, plots) are stored.
+BASE_DATA_DIR = Path("data")
+
+# Default path for the SQLite database that stores the scraped data.
+DEFAULT_DATABASE_PATH = BASE_DATA_DIR / "zap_rentals.sqlite"
+
+# Base URL for the public Zap Imóveis search API.
+ZAP_API_URL = "https://glue-api.zapimoveis.com.br/v3/listings"
+
+# Amount of listings requested per page. The API accepts values up to 50.
+DEFAULT_PAGE_SIZE = 50
+
+# Default timeout (in seconds) for HTTP requests.
+DEFAULT_TIMEOUT = 30
+
+# Seconds to wait between consecutive requests to avoid overloading the API.
+DEFAULT_DELAY_BETWEEN_REQUESTS = 1.5

--- a/realstate/main.py
+++ b/realstate/main.py
@@ -1,0 +1,184 @@
+"""Command line interface for the Zap Imóveis scraping toolkit."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+from pathlib import Path
+from typing import Iterable, List
+
+from .config import (
+    DEFAULT_DATABASE_PATH,
+    DEFAULT_DELAY_BETWEEN_REQUESTS,
+    DEFAULT_NEIGHBORHOODS,
+    Neighborhood,
+)
+from .reporting import plot_listing_price_history, plot_neighborhood_average_price
+from .scraper import ZapScraper
+from .storage import RealEstateDatabase
+
+
+def parse_arguments(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Ferramenta para coletar diariamente preços de aluguel por m² em São Paulo usando o Zap Imóveis."
+        )
+    )
+    parser.add_argument(
+        "--database",
+        type=Path,
+        default=DEFAULT_DATABASE_PATH,
+        help="Caminho do banco SQLite onde os dados serão armazenados.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Nível de verbosidade do log.",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    collect_parser = subparsers.add_parser(
+        "collect", help="Executa o processo de coleta de dados a partir do Zap Imóveis."
+    )
+    collect_parser.add_argument(
+        "--neighborhood",
+        dest="neighborhoods",
+        action="append",
+        help="Lista de bairros a coletar. Pode ser utilizado múltiplas vezes.",
+    )
+    collect_parser.add_argument(
+        "--max-pages",
+        type=int,
+        default=None,
+        help="Número máximo de páginas por bairro (útil para testes).",
+    )
+    collect_parser.add_argument(
+        "--delay",
+        type=float,
+        default=DEFAULT_DELAY_BETWEEN_REQUESTS,
+        help="Intervalo em segundos entre requisições consecutivas ao servidor.",
+    )
+    collect_parser.add_argument(
+        "--daily",
+        action="store_true",
+        help="Mantém a coleta ativa diariamente (executa novamente a cada 24h).",
+    )
+    collect_parser.add_argument(
+        "--interval-hours",
+        type=float,
+        default=24.0,
+        help="Intervalo em horas entre execuções quando --daily é usado.",
+    )
+
+    report_parser = subparsers.add_parser(
+        "report", help="Gera relatórios e gráficos a partir dos dados coletados."
+    )
+    report_subparsers = report_parser.add_subparsers(dest="report_type", required=True)
+
+    listing_report = report_subparsers.add_parser(
+        "listing", help="Gera gráfico de variação de preço para um imóvel específico."
+    )
+    listing_report.add_argument("listing_id", help="Identificador do imóvel no Zap Imóveis.")
+    listing_report.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Arquivo onde o gráfico será salvo. Se omitido, será exibido na tela.",
+    )
+    listing_report.add_argument(
+        "--show",
+        action="store_true",
+        help="Exibe o gráfico na tela (requer ambiente gráfico).",
+    )
+
+    neighborhood_report = report_subparsers.add_parser(
+        "neighborhood", help="Gera gráfico do preço médio por m² para um bairro."
+    )
+    neighborhood_report.add_argument("neighborhood", help="Nome do bairro.")
+    neighborhood_report.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Arquivo onde o gráfico será salvo. Se omitido, será exibido na tela.",
+    )
+    neighborhood_report.add_argument(
+        "--show",
+        action="store_true",
+        help="Exibe o gráfico na tela (requer ambiente gráfico).",
+    )
+
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_arguments(argv)
+    logging.basicConfig(level=getattr(logging, args.log_level), format="%(asctime)s %(levelname)s %(message)s")
+    logging.debug("Argumentos recebidos: %s", args)
+
+    database_path: Path = args.database
+    database_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if args.command == "collect":
+        run_collection(database_path, args)
+    elif args.command == "report":
+        run_report(database_path, args)
+    else:  # pragma: no cover - defensive programming
+        raise ValueError(f"Comando desconhecido: {args.command}")
+
+    return 0
+
+
+def run_collection(database_path: Path, args: argparse.Namespace) -> None:
+    neighborhoods = _resolve_neighborhoods(args.neighborhoods)
+    interval_seconds = max(0.0, float(args.interval_hours) * 3600.0)
+
+    def single_run() -> None:
+        logging.info("Iniciando coleta de dados para %s bairros", len(neighborhoods))
+        scraper = ZapScraper(neighborhoods=neighborhoods, delay=args.delay)
+        db = RealEstateDatabase(database_path)
+        total = db.persist_many(scraper.scrape(max_pages=args.max_pages))
+        logging.info("Coleta finalizada. %s registros processados.", total)
+
+    single_run()
+
+    if args.daily:
+        while True:
+            logging.info("Aguardando %s horas para a próxima execução.", args.interval_hours)
+            time.sleep(interval_seconds)
+            try:
+                single_run()
+            except Exception:  # pragma: no cover - runtime safeguard
+                logging.exception("Erro durante a coleta diária. Retentando na próxima janela.")
+
+
+def run_report(database_path: Path, args: argparse.Namespace) -> None:
+    if args.report_type == "listing":
+        plot_listing_price_history(
+            database_path,
+            args.listing_id,
+            output_path=args.output,
+            show=args.show,
+        )
+    elif args.report_type == "neighborhood":
+        plot_neighborhood_average_price(
+            database_path,
+            args.neighborhood,
+            output_path=args.output,
+            show=args.show,
+        )
+    else:  # pragma: no cover
+        raise ValueError(f"Tipo de relatório desconhecido: {args.report_type}")
+
+
+def _resolve_neighborhoods(custom: List[str] | None) -> List[Neighborhood]:
+    if not custom:
+        return DEFAULT_NEIGHBORHOODS
+    return [Neighborhood(name=name, query=name) for name in custom]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/realstate/reporting.py
+++ b/realstate/reporting.py
@@ -1,0 +1,149 @@
+"""Utility functions for generating plots and analytical summaries."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from .storage import RealEstateDatabase
+
+
+class PlottingError(RuntimeError):
+    """Raised when generating a plot fails due to missing data."""
+
+
+def _ensure_matplotlib():
+    try:
+        import matplotlib.pyplot as plt  # type: ignore
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+        raise ModuleNotFoundError(
+            "matplotlib is required to generate charts. Install it with 'pip install matplotlib'."
+        ) from exc
+    return plt
+
+
+def plot_listing_price_history(
+    database_path: Path | str,
+    listing_id: str,
+    *,
+    output_path: Optional[Path | str] = None,
+    show: bool = False,
+):
+    """Generates a chart with the historic rental price for a single listing."""
+
+    db = RealEstateDatabase(database_path)
+    rows = db.get_listing_history(listing_id)
+    if not rows:
+        raise PlottingError(
+            f"Nenhum registro encontrado para o imóvel {listing_id}. Execute a coleta primeiro."
+        )
+
+    plt = _ensure_matplotlib()
+
+    dates = [_parse_datetime(row["captured_at"]) for row in rows]
+    rent_prices = [row["rent_price"] for row in rows]
+    ppm_values = [row["price_per_m2"] for row in rows]
+
+    fig, ax1 = plt.subplots(figsize=(10, 6))
+    ax1.plot(dates, rent_prices, marker="o", color="tab:blue", label="Aluguel total (R$)")
+    ax1.set_xlabel("Data de captura")
+    ax1.set_ylabel("Aluguel total (R$)")
+    ax1.grid(True, axis="y", linestyle="--", alpha=0.3)
+
+    handles, labels = ax1.get_legend_handles_labels()
+
+    if any(value is not None for value in ppm_values):
+        valid_dates = [d for d, v in zip(dates, ppm_values) if v is not None]
+        valid_values = [v for v in ppm_values if v is not None]
+        if valid_values:
+            ax2 = ax1.twinx()
+            ax2.plot(
+                valid_dates,
+                valid_values,
+                marker="s",
+                color="tab:orange",
+                label="Preço por m² (R$)",
+            )
+            ax2.set_ylabel("Preço por m² (R$)")
+            h2, l2 = ax2.get_legend_handles_labels()
+            handles.extend(h2)
+            labels.extend(l2)
+
+    title = rows[0]["title"] if rows[0]["title"] else f"Imóvel {listing_id}"
+    subtitle = rows[0]["neighborhood"] if rows[0]["neighborhood"] else "São Paulo"
+    ax1.set_title(f"{title}\n{subtitle}")
+
+    if handles:
+        fig.legend(handles, labels, loc="upper left", bbox_to_anchor=(0.1, 0.95))
+
+    _save_or_show(fig, output_path, show)
+
+
+def plot_neighborhood_average_price(
+    database_path: Path | str,
+    neighborhood: str,
+    *,
+    output_path: Optional[Path | str] = None,
+    show: bool = False,
+):
+    """Generates a chart with the daily average price per m² in a neighbourhood."""
+
+    db = RealEstateDatabase(database_path)
+    furnished_rows = db.get_neighborhood_daily_average(neighborhood, furnished=True)
+    unfurnished_rows = db.get_neighborhood_daily_average(neighborhood, furnished=False)
+
+    if not furnished_rows and not unfurnished_rows:
+        raise PlottingError(
+            f"Nenhum dado histórico encontrado para o bairro {neighborhood}. Execute a coleta primeiro."
+        )
+
+    plt = _ensure_matplotlib()
+    fig, ax = plt.subplots(figsize=(10, 6))
+
+    def add_series(rows, label, color):
+        if not rows:
+            return
+        parsed = [
+            (_parse_date(row["captured_date"]), row["avg_price_per_m2"])
+            for row in rows
+            if row["avg_price_per_m2"] is not None
+        ]
+        if not parsed:
+            return
+        dates, values = zip(*parsed)
+        ax.plot(dates, values, marker="o", label=label, color=color)
+
+    add_series(furnished_rows, "Mobiliados", "tab:green")
+    add_series(unfurnished_rows, "Não mobiliados", "tab:red")
+
+    ax.set_title(f"Preço médio por m² - {neighborhood}")
+    ax.set_xlabel("Data")
+    ax.set_ylabel("Preço médio por m² (R$)")
+    ax.grid(True, axis="y", linestyle="--", alpha=0.3)
+    ax.legend(loc="best")
+
+    _save_or_show(fig, output_path, show)
+
+
+def _parse_datetime(value: str) -> datetime:
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:  # pragma: no cover - defensive path
+        return datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
+
+
+def _parse_date(value: str) -> datetime:
+    return datetime.fromisoformat(value)
+
+
+def _save_or_show(fig, output_path: Optional[Path | str], show: bool):
+    plt = _ensure_matplotlib()
+    if output_path:
+        output_path = Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        fig.tight_layout()
+        fig.savefig(output_path, bbox_inches="tight")
+    if show:
+        plt.show()
+    plt.close(fig)

--- a/realstate/scraper.py
+++ b/realstate/scraper.py
@@ -1,0 +1,320 @@
+"""Tools for downloading and normalising rental listings from Zap Imóveis."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict, Iterable, Iterator, List, Optional
+
+from .config import (
+    DEFAULT_DELAY_BETWEEN_REQUESTS,
+    DEFAULT_NEIGHBORHOODS,
+    DEFAULT_PAGE_SIZE,
+    DEFAULT_TIMEOUT,
+    Neighborhood,
+    ZAP_API_URL,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class Listing:
+    """Represents a simplified rental listing."""
+
+    listing_id: str
+    title: str
+    neighborhood: str
+    street: str
+    city: str
+    state: str
+    area_m2: Optional[float]
+    bedrooms: Optional[int]
+    bathrooms: Optional[int]
+    parking_spaces: Optional[int]
+    rent_price: Optional[float]
+    condo_fee: Optional[float]
+    price_per_m2: Optional[float]
+    furnished: bool
+    url: str
+    captured_at: datetime
+
+    @property
+    def captured_date(self) -> str:
+        """Returns the capture date (YYYY-MM-DD)."""
+
+        return self.captured_at.date().isoformat()
+
+
+class ZapScraper:
+    """Scraper responsible for collecting rental data from Zap Imóveis."""
+
+    def __init__(
+        self,
+        neighborhoods: Iterable[Neighborhood] | None = None,
+        *,
+        page_size: int = DEFAULT_PAGE_SIZE,
+        timeout: int = DEFAULT_TIMEOUT,
+        delay: float = DEFAULT_DELAY_BETWEEN_REQUESTS,
+        transport=None,
+    ) -> None:
+        self.neighborhoods = list(neighborhoods or DEFAULT_NEIGHBORHOODS)
+        self.page_size = page_size
+        self.timeout = timeout
+        self.delay = delay
+        self.transport = transport or self._default_transport
+
+    # ------------------------------------------------------------------
+    # Networking helpers
+    # ------------------------------------------------------------------
+    def _default_transport(self, url: str) -> bytes:
+        """Downloads the raw response from the provided URL."""
+
+        request = urllib.request.Request(
+            url,
+            headers={
+                "User-Agent": "Mozilla/5.0 (compatible; RealstateBot/1.0)",
+                "Accept": "application/json, text/plain, */*",
+                "Accept-Language": "pt-BR,pt;q=0.9",
+            },
+            method="GET",
+        )
+        with urllib.request.urlopen(request, timeout=self.timeout) as response:
+            if response.status != 200:
+                raise RuntimeError(f"Unexpected status code {response.status} for {url}")
+            return response.read()
+
+    # ------------------------------------------------------------------
+    def _build_params(self, neighborhood: Neighborhood, page: int) -> Dict[str, str]:
+        return {
+            "addressCity": "Sao Paulo",
+            "addressState": "SP",
+            "addressNeighborhood": neighborhood.query,
+            "business": "RENTAL",
+            "category": "APARTMENT",
+            "listingType": "USED",
+            "page": str(page),
+            "size": str(self.page_size),
+            "order": "update",
+            "direction": "desc",
+        }
+
+    def _build_url(self, neighborhood: Neighborhood, page: int) -> str:
+        params = self._build_params(neighborhood, page)
+        return f"{ZAP_API_URL}?{urllib.parse.urlencode(params)}"
+
+    def _fetch_page(self, neighborhood: Neighborhood, page: int) -> Dict[str, object]:
+        url = self._build_url(neighborhood, page)
+        LOGGER.debug("Fetching %s", url)
+        raw_response = self.transport(url)
+        try:
+            return json.loads(raw_response.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"Failed to parse JSON from {url}: {exc}") from exc
+
+    # ------------------------------------------------------------------
+    def iterate_listings(
+        self, neighborhood: Neighborhood, *, max_pages: Optional[int] = None
+    ) -> Iterator[Listing]:
+        """Iterates through all listings for a neighbourhood."""
+
+        page = 1
+        seen_ids: set[str] = set()
+        while True:
+            if max_pages is not None and page > max_pages:
+                break
+            payload = self._fetch_page(neighborhood, page)
+            raw_listings = self._extract_raw_listings(payload)
+            if not raw_listings:
+                LOGGER.debug("No listings returned for %s on page %s", neighborhood.name, page)
+                break
+            for raw_listing in raw_listings:
+                listing = self._normalise_listing(raw_listing)
+                if listing is None:
+                    continue
+                if listing.listing_id in seen_ids:
+                    continue
+                seen_ids.add(listing.listing_id)
+                yield listing
+            if len(raw_listings) < self.page_size:
+                break
+            page += 1
+            if self.delay:
+                time.sleep(self.delay)
+
+    def scrape(self, *, max_pages: Optional[int] = None) -> Iterator[Listing]:
+        """Scrapes all configured neighbourhoods."""
+
+        for neighborhood in self.neighborhoods:
+            LOGGER.info("Scraping neighbourhood %s", neighborhood.name)
+            yield from self.iterate_listings(neighborhood, max_pages=max_pages)
+
+    # ------------------------------------------------------------------
+    def _extract_raw_listings(self, payload: Dict[str, object]) -> List[Dict[str, object]]:
+        listings = payload.get("listings")
+        if not isinstance(listings, list):
+            return []
+        results: List[Dict[str, object]] = []
+        for item in listings:
+            if isinstance(item, dict):
+                if "listing" in item and isinstance(item["listing"], dict):
+                    results.append(item["listing"])
+                else:
+                    results.append(item)
+        return results
+
+    def _normalise_listing(self, raw: Dict[str, object]) -> Optional[Listing]:
+        listing_id = self._get_listing_id(raw)
+        if not listing_id:
+            return None
+        address = raw.get("address") or {}
+        if not isinstance(address, dict):
+            address = {}
+        neighborhood = self._safe_str(address.get("neighborhood"))
+        city = self._safe_str(address.get("city"))
+        state = self._safe_str(address.get("state"))
+        street = self._safe_str(address.get("street"))
+        area = self._get_first_number(raw.get("usableAreas"))
+        bedrooms = self._get_int(raw.get("bedrooms")) or self._get_int(raw.get("rooms"))
+        bathrooms = self._get_int(raw.get("bathrooms"))
+        parking = self._get_int(raw.get("parkingSpaces"))
+        furnished = self._is_furnished(raw)
+        pricing_info = self._select_pricing_info(raw.get("pricingInfos"))
+        rent_price = self._parse_price(pricing_info)
+        condo_fee = self._parse_fee(pricing_info)
+        price_per_m2 = None
+        if area and rent_price:
+            try:
+                price_per_m2 = rent_price / area
+            except ZeroDivisionError:
+                price_per_m2 = None
+        title = self._safe_str(raw.get("title")) or self._safe_str(raw.get("advertiseTitle"))
+        if not title:
+            title = f"Apartamento em {neighborhood}" if neighborhood else "Apartamento"
+        url = self._extract_url(raw)
+        captured_at = datetime.now(timezone.utc)
+        return Listing(
+            listing_id=listing_id,
+            title=title,
+            neighborhood=neighborhood,
+            street=street,
+            city=city,
+            state=state,
+            area_m2=area,
+            bedrooms=bedrooms,
+            bathrooms=bathrooms,
+            parking_spaces=parking,
+            rent_price=rent_price,
+            condo_fee=condo_fee,
+            price_per_m2=price_per_m2,
+            furnished=furnished,
+            url=url,
+            captured_at=captured_at,
+        )
+
+    # ------------------------------------------------------------------
+    def _get_listing_id(self, raw: Dict[str, object]) -> Optional[str]:
+        for key in ("id", "listingId", "detailId"):
+            value = raw.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return None
+
+    def _safe_str(self, value: object) -> str:
+        if isinstance(value, str):
+            return value.strip()
+        return ""
+
+    def _get_first_number(self, value: object) -> Optional[float]:
+        if isinstance(value, list) and value:
+            for element in value:
+                number = self._get_float(element)
+                if number is not None:
+                    return number
+        return self._get_float(value)
+
+    def _get_float(self, value: object) -> Optional[float]:
+        if value is None:
+            return None
+        if isinstance(value, (int, float)):
+            return float(value)
+        if isinstance(value, str):
+            cleaned = value.replace(".", "").replace(",", "")
+            try:
+                return float(cleaned)
+            except ValueError:
+                return None
+        return None
+
+    def _get_int(self, value: object) -> Optional[int]:
+        if value is None:
+            return None
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float):
+            return int(value)
+        if isinstance(value, str):
+            try:
+                return int(value.strip())
+            except ValueError:
+                return None
+        return None
+
+    def _is_furnished(self, raw: Dict[str, object]) -> bool:
+        if isinstance(raw.get("furnished"), bool):
+            return bool(raw["furnished"])
+        amenities = raw.get("amenities")
+        if isinstance(amenities, list):
+            normalized = {str(item).strip().upper() for item in amenities}
+            if "FURNISHED" in normalized or "MOBILIADO" in normalized:
+                return True
+        # Some listings expose furniture information in features
+        features = raw.get("features")
+        if isinstance(features, list):
+            normalized = {str(item).strip().upper() for item in features}
+            if "FURNISHED" in normalized or "MOBILIADO" in normalized:
+                return True
+        return False
+
+    def _select_pricing_info(self, value: object) -> Dict[str, object]:
+        if isinstance(value, dict):
+            return value
+        if isinstance(value, list):
+            for item in value:
+                if isinstance(item, dict):
+                    if item.get("businessType") == "RENTAL":
+                        return item
+            for item in value:
+                if isinstance(item, dict):
+                    return item
+        return {}
+
+    def _parse_price(self, info: Dict[str, object]) -> Optional[float]:
+        for key in ("rentalTotalPrice", "price", "value"):
+            price = self._get_float(info.get(key))
+            if price is not None:
+                return price
+        return None
+
+    def _parse_fee(self, info: Dict[str, object]) -> Optional[float]:
+        fee = info.get("monthlyCondoFee") or info.get("condominium")
+        return self._get_float(fee)
+
+    def _extract_url(self, raw: Dict[str, object]) -> str:
+        for key in ("url", "link", "detailUrl"):
+            value = raw.get(key)
+            if isinstance(value, str) and value.startswith("http"):
+                return value
+            if isinstance(value, dict):
+                href = value.get("href")
+                if isinstance(href, str) and href.startswith("http"):
+                    return href
+        listing_id = self._get_listing_id(raw)
+        if listing_id:
+            return f"https://www.zapimoveis.com.br/imovel/{listing_id}"
+        return "https://www.zapimoveis.com.br"

--- a/realstate/storage.py
+++ b/realstate/storage.py
@@ -1,0 +1,205 @@
+"""Persistence layer responsible for storing the scraped data."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from .scraper import Listing
+
+
+class RealEstateDatabase:
+    """Small wrapper around SQLite used to persist listing information."""
+
+    def __init__(self, database_path: Path | str) -> None:
+        self.database_path = Path(database_path)
+        self.database_path.parent.mkdir(parents=True, exist_ok=True)
+        self._ensure_schema()
+
+    # ------------------------------------------------------------------
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.database_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA foreign_keys = ON")
+        return conn
+
+    def _ensure_schema(self) -> None:
+        with self._connect() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS listings (
+                    listing_id TEXT PRIMARY KEY,
+                    title TEXT,
+                    neighborhood TEXT,
+                    street TEXT,
+                    city TEXT,
+                    state TEXT,
+                    area_m2 REAL,
+                    bedrooms INTEGER,
+                    bathrooms INTEGER,
+                    parking_spaces INTEGER,
+                    furnished INTEGER,
+                    url TEXT,
+                    first_seen TEXT,
+                    last_seen TEXT
+                )
+                """
+            )
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS price_history (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    listing_id TEXT NOT NULL,
+                    captured_at TEXT NOT NULL,
+                    rent_price REAL,
+                    price_per_m2 REAL,
+                    condo_fee REAL,
+                    furnished INTEGER NOT NULL,
+                    UNIQUE(listing_id, captured_at),
+                    FOREIGN KEY(listing_id) REFERENCES listings(listing_id) ON DELETE CASCADE
+                )
+                """
+            )
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    def persist_listing(self, listing: Listing) -> None:
+        with self._connect() as conn:
+            cursor = conn.cursor()
+            self._persist_listing_with_cursor(cursor, listing)
+            conn.commit()
+
+    def persist_many(self, listings: Iterable[Listing]) -> int:
+        count = 0
+        with self._connect() as conn:
+            cursor = conn.cursor()
+            for listing in listings:
+                self._persist_listing_with_cursor(cursor, listing)
+                count += 1
+            conn.commit()
+        return count
+
+    def _persist_listing_with_cursor(self, cursor: sqlite3.Cursor, listing: Listing) -> None:
+        cursor.execute(
+            """
+            INSERT INTO listings (
+                listing_id, title, neighborhood, street, city, state,
+                area_m2, bedrooms, bathrooms, parking_spaces, furnished,
+                url, first_seen, last_seen
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(listing_id) DO UPDATE SET
+                title=excluded.title,
+                neighborhood=excluded.neighborhood,
+                street=excluded.street,
+                city=excluded.city,
+                state=excluded.state,
+                area_m2=excluded.area_m2,
+                bedrooms=excluded.bedrooms,
+                bathrooms=excluded.bathrooms,
+                parking_spaces=excluded.parking_spaces,
+                furnished=excluded.furnished,
+                url=excluded.url,
+                last_seen=excluded.last_seen
+            """,
+            (
+                listing.listing_id,
+                listing.title,
+                listing.neighborhood,
+                listing.street,
+                listing.city,
+                listing.state,
+                listing.area_m2,
+                listing.bedrooms,
+                listing.bathrooms,
+                listing.parking_spaces,
+                int(listing.furnished),
+                listing.url,
+                listing.captured_at.isoformat(),
+                listing.captured_at.isoformat(),
+            ),
+        )
+        cursor.execute(
+            """
+            INSERT INTO price_history (
+                listing_id, captured_at, rent_price, price_per_m2, condo_fee, furnished
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(listing_id, captured_at) DO UPDATE SET
+                rent_price=excluded.rent_price,
+                price_per_m2=excluded.price_per_m2,
+                condo_fee=excluded.condo_fee,
+                furnished=excluded.furnished
+            """,
+            (
+                listing.listing_id,
+                listing.captured_at.isoformat(),
+                listing.rent_price,
+                listing.price_per_m2,
+                listing.condo_fee,
+                int(listing.furnished),
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    def get_listing_history(self, listing_id: str) -> List[sqlite3.Row]:
+        with self._connect() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT
+                    l.listing_id,
+                    l.title,
+                    l.neighborhood,
+                    l.street,
+                    ph.captured_at,
+                    ph.rent_price,
+                    ph.price_per_m2,
+                    ph.condo_fee,
+                    ph.furnished
+                FROM price_history AS ph
+                JOIN listings AS l ON l.listing_id = ph.listing_id
+                WHERE l.listing_id = ?
+                ORDER BY ph.captured_at ASC
+                """,
+                (listing_id,),
+            )
+            return cursor.fetchall()
+
+    def get_neighborhood_daily_average(
+        self, neighborhood: str, *, furnished: Optional[bool] = None
+    ) -> List[sqlite3.Row]:
+        query = [
+            "SELECT",
+            "    date(ph.captured_at) AS captured_date,",
+            "    AVG(ph.rent_price) AS avg_rent_price,",
+            "    AVG(ph.price_per_m2) AS avg_price_per_m2,",
+            "    COUNT(*) AS listings",
+            "FROM price_history AS ph",
+            "JOIN listings AS l ON l.listing_id = ph.listing_id",
+            "WHERE l.neighborhood = ?",
+        ]
+        params: List[object] = [neighborhood]
+        if furnished is not None:
+            query.append("AND ph.furnished = ?")
+            params.append(1 if furnished else 0)
+        query.append("GROUP BY captured_date")
+        query.append("ORDER BY captured_date ASC")
+        sql = "\n".join(query)
+        with self._connect() as conn:
+            cursor = conn.cursor()
+            cursor.execute(sql, params)
+            return cursor.fetchall()
+
+    def list_listings(self, neighborhood: Optional[str] = None) -> List[sqlite3.Row]:
+        with self._connect() as conn:
+            cursor = conn.cursor()
+            if neighborhood:
+                cursor.execute(
+                    "SELECT * FROM listings WHERE neighborhood = ? ORDER BY title",
+                    (neighborhood,),
+                )
+            else:
+                cursor.execute("SELECT * FROM listings ORDER BY neighborhood, title")
+            return cursor.fetchall()

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+from realstate.config import Neighborhood
+from realstate.scraper import ZapScraper
+
+
+def load_fixture() -> bytes:
+    fixture_path = Path(__file__).resolve().parent.parent / "fixtures" / "sample_api_response.json"
+    return fixture_path.read_bytes()
+
+
+class ScraperTests(unittest.TestCase):
+    def test_scraper_normalises_listings(self):
+        responses = [load_fixture(), json.dumps({"listings": []}).encode("utf-8")]
+
+        def fake_transport(_url: str) -> bytes:
+            return responses.pop(0)
+
+        scraper = ZapScraper(
+            neighborhoods=[Neighborhood(name="Pinheiros", query="Pinheiros")],
+            transport=fake_transport,
+        )
+
+        listings = list(scraper.scrape())
+
+        self.assertEqual(len(listings), 2)
+
+        first = listings[0]
+        self.assertEqual(first.listing_id, "12345")
+        self.assertEqual(first.neighborhood, "Pinheiros")
+        self.assertTrue(first.furnished)
+        self.assertEqual(first.rent_price, 4800.0)
+        self.assertEqual(first.price_per_m2, 60.0)
+        self.assertTrue(first.url.startswith("https://www.zapimoveis.com.br/imovel/12345"))
+
+        second = listings[1]
+        self.assertEqual(second.listing_id, "67890")
+        self.assertEqual(second.neighborhood, "Moema")
+        self.assertFalse(second.furnished)
+        self.assertEqual(second.rent_price, 6000.0)
+        self.assertEqual(second.price_per_m2, 60.0)
+        self.assertTrue(second.url.endswith("67890"))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from realstate.scraper import Listing
+from realstate.storage import RealEstateDatabase
+
+
+def make_listing(
+    listing_id: str,
+    *,
+    captured_at: datetime,
+    rent_price: float,
+    price_per_m2: float,
+    neighborhood: str = "Pinheiros",
+    furnished: bool = True,
+) -> Listing:
+    return Listing(
+        listing_id=listing_id,
+        title="Apartamento de teste",
+        neighborhood=neighborhood,
+        street="Rua Teste",
+        city="São Paulo",
+        state="SP",
+        area_m2=80.0,
+        bedrooms=2,
+        bathrooms=2,
+        parking_spaces=1,
+        rent_price=rent_price,
+        condo_fee=500.0,
+        price_per_m2=price_per_m2,
+        furnished=furnished,
+        url=f"https://www.zapimoveis.com.br/imovel/{listing_id}",
+        captured_at=captured_at,
+    )
+
+
+class StorageTests(unittest.TestCase):
+    def test_database_persists_history(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            db_path = Path(tmp_dir) / "rentals.sqlite"
+            db = RealEstateDatabase(db_path)
+
+            first_capture = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+            second_capture = first_capture + timedelta(days=1)
+
+            listing = make_listing(
+                "ABC123",
+                captured_at=first_capture,
+                rent_price=5000.0,
+                price_per_m2=62.5,
+                furnished=True,
+            )
+            db.persist_listing(listing)
+
+            updated = make_listing(
+                "ABC123",
+                captured_at=second_capture,
+                rent_price=5200.0,
+                price_per_m2=65.0,
+                furnished=True,
+            )
+            db.persist_listing(updated)
+
+            history = db.get_listing_history("ABC123")
+            self.assertEqual(len(history), 2)
+            self.assertEqual(history[0]["rent_price"], 5000.0)
+            self.assertEqual(history[1]["rent_price"], 5200.0)
+
+            averages = db.get_neighborhood_daily_average("Pinheiros", furnished=True)
+            self.assertEqual(len(averages), 2)
+            self.assertEqual(averages[0]["avg_price_per_m2"], 62.5)
+            self.assertEqual(averages[1]["avg_price_per_m2"], 65.0)
+
+            listings = db.list_listings("Pinheiros")
+            self.assertEqual(len(listings), 1)
+            self.assertEqual(listings[0]["listing_id"], "ABC123")
+            self.assertEqual(listings[0]["furnished"], 1)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement a Zap Imóveis scraper that normalises rental listings for the targeted São Paulo neighbourhoods
- persist listing snapshots and price history in SQLite and expose a CLI for daily collection
- add reporting utilities, documentation and fixtures alongside unit tests that validate parsing and storage

## Testing
- python -m unittest discover -s tests -p 'test_*.py'

------
https://chatgpt.com/codex/tasks/task_e_68cedeccb788832ab6f569a03fc0cf30